### PR TITLE
Exporting TimeZone interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ interface TimeZone {
   utc: string;
 }
 
+export { TimeZone };
 export default timezones as TimeZone[];


### PR DESCRIPTION
If used in TS, the interface is not available, forces the consumer to re-define if would like to specify further variables of same type, e.g.:

```
import timeZonesArray from 'timezones-list';

type ArrayTypeOf<T extends any[]> = T extends (infer U)[] ? U : never;
type TimeZone = ArrayTypeOf<typeof timeZonesArray>;

const timeZone: TimeZone = timeZonesArray[0];
```