### PR TITLE
remove source files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Om Srivastava",
   "license": "MIT",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "homepage": "https://github.com/omsrivastava/timezones#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In [npm package](https://www.npmjs.com/package/timezones-list) `timezones.json` is duplicated in `src` and `dist` folders.

To reduce the package size, I have changed `package.json` to accept only `dist` folder (plus `package.json`, `README` and `LICENSE`) on package and building.